### PR TITLE
Add Cloud Deploy pipeline and build configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # dead-simpl-infra
+
+Infrastructure code for Dead Simpl environments.
+
+## CI/CD
+
+The `clouddeploy` directory defines a Google Cloud Deploy pipeline with staging and production targets.
+
+Use `cloudbuild.backend.yaml` and `cloudbuild.frontend.yaml` in the application repositories to build images and create Cloud Deploy releases.

--- a/cloudbuild.backend.yaml
+++ b/cloudbuild.backend.yaml
@@ -1,0 +1,17 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build','-t','us-central1-docker.pkg.dev/$PROJECT_ID/backend/backend:$COMMIT_SHA','.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push','us-central1-docker.pkg.dev/$PROJECT_ID/backend/backend:$COMMIT_SHA']
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args:
+  - deploy
+  - releases
+  - create
+  - backend-$COMMIT_SHA
+  - --delivery-pipeline=dead-simpl
+  - --region=us-central1
+  - --images=backend=us-central1-docker.pkg.dev/$PROJECT_ID/backend/backend:$COMMIT_SHA
+images:
+- us-central1-docker.pkg.dev/$PROJECT_ID/backend/backend:$COMMIT_SHA

--- a/cloudbuild.frontend.yaml
+++ b/cloudbuild.frontend.yaml
@@ -1,0 +1,17 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build','-t','us-central1-docker.pkg.dev/$PROJECT_ID/frontend/frontend:$COMMIT_SHA','.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push','us-central1-docker.pkg.dev/$PROJECT_ID/frontend/frontend:$COMMIT_SHA']
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args:
+  - deploy
+  - releases
+  - create
+  - frontend-$COMMIT_SHA
+  - --delivery-pipeline=dead-simpl
+  - --region=us-central1
+  - --images=frontend=us-central1-docker.pkg.dev/$PROJECT_ID/frontend/frontend:$COMMIT_SHA
+images:
+- us-central1-docker.pkg.dev/$PROJECT_ID/frontend/frontend:$COMMIT_SHA

--- a/clouddeploy/main.tf
+++ b/clouddeploy/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Cloud Deploy targets for staging and production
+resource "google_clouddeploy_target" "staging" {
+  project  = var.project_id
+  location = var.region
+  name     = "staging"
+
+  gke {
+    cluster = "projects/${var.project_id}/locations/${var.region}/clusters/staging-cluster"
+  }
+}
+
+resource "google_clouddeploy_target" "prod" {
+  project  = var.project_id
+  location = var.region
+  name     = "prod"
+
+  gke {
+    cluster = "projects/${var.project_id}/locations/${var.region}/clusters/prod-cluster"
+  }
+}
+
+# Delivery pipeline connecting the targets
+resource "google_clouddeploy_delivery_pipeline" "dead_simpl" {
+  project  = var.project_id
+  location = var.region
+  name     = "dead-simpl"
+
+  serial_pipeline {
+    stages {
+      target_id = google_clouddeploy_target.staging.name
+    }
+    stages {
+      target_id = google_clouddeploy_target.prod.name
+    }
+  }
+}

--- a/clouddeploy/terraform.tfvars
+++ b/clouddeploy/terraform.tfvars
@@ -1,0 +1,1 @@
+project_id = "halogen-eon-470613-h3"

--- a/clouddeploy/variables.tf
+++ b/clouddeploy/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "The GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region for Cloud Deploy resources."
+  type        = string
+  default     = "us-central1"
+}

--- a/production/main.tf
+++ b/production/main.tf
@@ -91,9 +91,9 @@ resource "google_compute_global_address" "backend_prod_ip" {
 }
 
 resource "helm_release" "backend_prod" {
-  name       = "backend-prod"
-  chart      = "/Users/mcclainthiel/Documents/dead-simpl/helm/backend"
-  namespace  = "production"
+  name             = "backend-prod"
+  chart            = "/Users/mcclainthiel/Documents/dead-simpl/helm/backend"
+  namespace        = "production"
   create_namespace = true
 
   values = [
@@ -102,9 +102,9 @@ resource "helm_release" "backend_prod" {
 }
 
 resource "helm_release" "frontend_prod" {
-  name       = "frontend-prod"
-  chart      = "/Users/mcclainthiel/Documents/dead-simpl/helm/frontend"
-  namespace  = "production"
+  name             = "frontend-prod"
+  chart            = "/Users/mcclainthiel/Documents/dead-simpl/helm/frontend"
+  namespace        = "production"
   create_namespace = true
 
   values = [

--- a/production/terraform.tfvars
+++ b/production/terraform.tfvars
@@ -1,4 +1,4 @@
-project_id = "halogen-eon-470613-h3"
+project_id         = "halogen-eon-470613-h3"
 github_owner       = "mcclain-thiel"
 backend_repo_name  = "dead-simpl-backend"
 frontend_repo_name = "dead-simpl-frontend"

--- a/staging/main.tf
+++ b/staging/main.tf
@@ -120,24 +120,24 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 
 # CloudSQL Postgres instance for staging
 resource "google_sql_database_instance" "staging_postgres" {
-  name             = "staging-postgres"
-  database_version = "POSTGRES_15"
-  region           = var.region
+  name                = "staging-postgres"
+  database_version    = "POSTGRES_15"
+  region              = var.region
   deletion_protection = false
 
   depends_on = [google_service_networking_connection.private_vpc_connection]
 
   settings {
     tier = "db-f1-micro"
-    
+
     ip_configuration {
-      ipv4_enabled    = false
-      private_network = google_compute_network.vpc.id
+      ipv4_enabled                                  = false
+      private_network                               = google_compute_network.vpc.id
       enable_private_path_for_google_cloud_services = true
     }
-    
+
     backup_configuration {
-      enabled = true
+      enabled    = true
       start_time = "03:00"
     }
   }
@@ -175,13 +175,13 @@ resource "google_secret_manager_secret" "staging_db_url" {
 }
 
 resource "google_secret_manager_secret_version" "staging_db_url" {
-  secret = google_secret_manager_secret.staging_db_url.id
+  secret      = google_secret_manager_secret.staging_db_url.id
   secret_data = "postgresql://${google_sql_user.staging_user.name}:${random_password.db_password.result}@${google_sql_database_instance.staging_postgres.private_ip_address}/${google_sql_database.staging_db.name}"
 }
 
 # Create database URL secret in Kubernetes
 data "google_secret_manager_secret_version" "staging_db_url" {
-  secret = google_secret_manager_secret.staging_db_url.secret_id
+  secret     = google_secret_manager_secret.staging_db_url.secret_id
   depends_on = [google_secret_manager_secret_version.staging_db_url]
 }
 

--- a/staging/terraform.tfvars
+++ b/staging/terraform.tfvars
@@ -1,4 +1,4 @@
-project_id = "halogen-eon-470613-h3"
+project_id         = "halogen-eon-470613-h3"
 github_owner       = "mcclain-thiel"
 backend_repo_name  = "dead-simpl-backend"
 frontend_repo_name = "dead-simpl-frontend"


### PR DESCRIPTION
## Summary
- add Cloud Deploy pipeline with staging and prod targets
- provide Cloud Build configs for backend and frontend releases
- document CI/CD setup

## Testing
- `terraform init -backend=false` *(fails: could not retrieve provider hashicorp/google)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68be034d18588326832da19152c958e1